### PR TITLE
Fix bug in creating multiple network adapters

### DIFF
--- a/InvisibleMan-TUN/Handlers/ProfileHandler.cs
+++ b/InvisibleMan-TUN/Handlers/ProfileHandler.cs
@@ -1,0 +1,22 @@
+namespace InvisibleManTUN.Handlers
+{
+    using Profiles;
+
+    public class ProfileHandler : Handler
+    {
+        private readonly IProfile profile;
+
+        public ProfileHandler()
+        {
+            this.profile = LoadProfile();
+        }
+
+        public IProfile GetProfile() => profile;
+
+        private IProfile LoadProfile()
+        {
+            WindowsProfile windowsProfile = new WindowsProfile();
+            return windowsProfile;
+        }
+    }
+}

--- a/InvisibleMan-TUN/Handlers/Profiles/IProfile.cs
+++ b/InvisibleMan-TUN/Handlers/Profiles/IProfile.cs
@@ -1,0 +1,7 @@
+namespace InvisibleManTUN.Handlers.Profiles
+{
+    public interface IProfile
+    {
+        void CleanupProfiles(string profileName);
+    }
+}

--- a/InvisibleMan-TUN/Handlers/Profiles/WindowsProfile.cs
+++ b/InvisibleMan-TUN/Handlers/Profiles/WindowsProfile.cs
@@ -1,0 +1,53 @@
+using System;
+using Microsoft.Win32;
+
+namespace InvisibleManTUN.Handlers.Profiles
+{
+    public class WindowsProfile : IProfile
+    {
+        private const string NETWORK_PROFILE = @"SOFTWARE\Microsoft\Windows NT\CurrentVersion\NetworkList\Profiles";
+        private const string PROFILE_NAME = "ProfileName";
+
+        public void CleanupProfiles(string profileName)
+        {
+            try
+            {
+                RegistryKey baseKey = Registry.LocalMachine.OpenSubKey(
+                    name: NETWORK_PROFILE, 
+                    writable: true
+                );
+
+                if (!IsRegistryKeyExists(baseKey))
+                    return;
+                
+                string[] subKeyNames = baseKey.GetSubKeyNames();
+
+                foreach(string subKeyName in subKeyNames)
+                {
+                    RegistryKey subKey = baseKey.OpenSubKey(
+                        name: subKeyName,
+                        writable: true
+                    );
+
+                    if (!IsRegistryKeyExists(subKey))
+                        continue;
+                    
+                    object profileValue = subKey.GetValue(PROFILE_NAME);
+
+                    if (profileValue != null && profileValue is string prfileValueString)
+                        if (ShouldRemoveProfile(prfileValueString))
+                            baseKey.DeleteSubKey(subKeyName);
+                }
+            }
+            catch(Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+                return;
+            }
+
+            bool IsRegistryKeyExists(RegistryKey key) => key != null;
+
+            bool ShouldRemoveProfile(string name) => name.StartsWith(profileName);
+        }
+    }
+}

--- a/InvisibleMan-TUN/Handlers/TunnelHandler.cs
+++ b/InvisibleMan-TUN/Handlers/TunnelHandler.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 namespace InvisibleManTUN.Handlers
 {
     using Foundation;
+    using Handlers.Profiles;
     using Utilities;
 
     public class TunnelHandler : Handler
@@ -16,6 +17,7 @@ namespace InvisibleManTUN.Handlers
         private Action<string, string> onSetInterfaceDns;
         private Action<string, string, string, int> onSetRoutes;
         private Func<bool> isTunnelRunning;
+        private Func<IProfile> getProfile;
 
         public TunnelHandler()
         {
@@ -28,7 +30,8 @@ namespace InvisibleManTUN.Handlers
             Action<string, string> onSetInterfaceAddress,
             Action<string, string> onSetInterfaceDns,
             Action<string, string, string, int> onSetRoutes,
-            Func<bool> isTunnelRunning
+            Func<bool> isTunnelRunning,
+            Func<IProfile> getProfile
         )
         {
             this.onStopTunnel = onStopTunnel;
@@ -37,6 +40,7 @@ namespace InvisibleManTUN.Handlers
             this.onSetInterfaceDns = onSetInterfaceDns;
             this.onSetRoutes = onSetRoutes;
             this.isTunnelRunning = isTunnelRunning;
+            this.getProfile = getProfile;
         }
 
         public void Start(string device, string proxy, string address, string server, string dns)
@@ -44,7 +48,10 @@ namespace InvisibleManTUN.Handlers
             try
             {
                 if (!IsTunnelRunning())
+                {
+                    CleanupProfile();
                     StartTunnel();
+                }
 
                 WaitUntilInterfaceCreated();
                 SetInterfaceAddress();
@@ -61,6 +68,11 @@ namespace InvisibleManTUN.Handlers
             bool IsTunnelRunning()
             {
                 return isTunnelRunning.Invoke();
+            }
+
+            void CleanupProfile()
+            {
+                getProfile.Invoke().CleanupProfiles(device);
             }
 
             void StartTunnel()

--- a/InvisibleMan-TUN/InvisibleMan-TUN.csproj
+++ b/InvisibleMan-TUN/InvisibleMan-TUN.csproj
@@ -13,7 +13,7 @@
     <AssemblyVersion>0.3.3.0</AssemblyVersion>
     <ApplicationManifest>App.manifest</ApplicationManifest>
     <Nullable>enable</Nullable>
-    <NoWarn>8600;8602;8603;8604;8618</NoWarn>
+    <NoWarn>8600;8602;8603;8604;8618;CA1416</NoWarn>
     <ApplicationIcon>Assets/Icon.ico</ApplicationIcon>
     <PublishSingleFile>true</PublishSingleFile>
     <_SuppressWpfTrimError>true</_SuppressWpfTrimError>

--- a/InvisibleMan-TUN/Managers/ServiceManager.cs
+++ b/InvisibleMan-TUN/Managers/ServiceManager.cs
@@ -55,12 +55,14 @@ namespace InvisibleManTUN.Managers
 
             handlersManager.AddHandler(new SocketHandler());
             handlersManager.AddHandler(new TunnelHandler());
+            handlersManager.AddHandler(new ProfileHandler());
         }
 
         private void SetupHandlers()
         {
             TunnelHandler tunnelHandler = handlersManager.GetHandler<TunnelHandler>();
             SocketHandler socketHandler = handlersManager.GetHandler<SocketHandler>();
+            ProfileHandler profileHandler = handlersManager.GetHandler<ProfileHandler>();
 
             SetupSocketHandler();
             SetupTunnelHandler();
@@ -82,7 +84,8 @@ namespace InvisibleManTUN.Managers
                     onSetInterfaceAddress: core.SetInterfaceAddress,
                     onSetInterfaceDns: core.SetInterfaceDns,
                     onSetRoutes: core.SetRoutes,
-                    isTunnelRunning: core.IsTunnelRunning
+                    isTunnelRunning: core.IsTunnelRunning,
+                    getProfile: profileHandler.GetProfile
                 );
             }
         }


### PR DESCRIPTION
When you were running the app, it created a new network adapter profile and added an incremental number to it. In fact, it didn't remove the old profile so it generates a new one. In this fix, I resolved this issue.