### PR TITLE
Fix bug in checking the tunnel running status

### DIFF
--- a/TUN-Wrapper/tun/wrapper.go
+++ b/TUN-Wrapper/tun/wrapper.go
@@ -2,7 +2,6 @@ package tun
 
 import (
 	"C"
-	"bytes"
 	"fmt"
 	"os/exec"
 	"syscall"
@@ -81,6 +80,8 @@ func StopTunnel() {
 	}
 
 	fmt.Println("stopping tun2socks - pid:", pid)
+	cmd.Process.Kill()
+	cmd = nil
 }
 
 //export IsTunnelRunning
@@ -89,12 +90,5 @@ func IsTunnelRunning() bool {
 		return false
 	}
 
-	pid := cmd.Process.Pid
-	cmd := exec.Command("TASKLIST", "/FI", fmt.Sprintf("PID eq %d", pid))
-	result, err := cmd.Output()
-	if err != nil {
-		return false
-	}
-
-	return !bytes.Contains(result, []byte("No tasks are running"))
+	return true
 }


### PR DESCRIPTION
The `IsTunnelRunning()` function gave a wrong response in some scenarios. The most important problem was that it compares the response of `TASKLIST` to ensure if a process exists or not. That was not a good approach and caused problems if anyone used another language except English for their terminal.